### PR TITLE
Add trivial schema, update zss builder, and manifest, and changelog

### DIFF
--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -42,6 +42,7 @@ mkdir -p "${PAX_WORKSPACE_DIR}/content"
 echo "[${SCRIPT_NAME}] copying explorer-ip root files to PAX workspace"
 cp  pluginDefinition.json "${PAX_WORKSPACE_DIR}/content"
 cp  manifest.yaml "${PAX_WORKSPACE_DIR}/content"
+cp -r schemas "${PAX_WORKSPACE_DIR}/schemas"
 cp  README.md "${PAX_WORKSPACE_DIR}/content"
 cp  LICENSE "${PAX_WORKSPACE_DIR}/content"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# IP Explorer Changelog
+
+All notable changes to the sample angular app will be documented in this file.
+
+## 1.0.1
+
+- Bugfix: Schema file was not included, preventing installation as a component
+- Bugfix: Manifest build content template was never resolved, so it has been removed.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # IP Explorer Changelog
 
-All notable changes to the sample angular app will be documented in this file.
+All notable changes to the IP Explorer app will be documented in this file.
 
 ## 1.0.1
 

--- a/dataService/build/build31.sh
+++ b/dataService/build/build31.sh
@@ -22,7 +22,7 @@ rm -f "${TARGET}"
 if ! c89 -D_OPEN_THREADS -D_XOPEN_SOURCE=600 -DAPF_AUTHORIZED=0 -DNOIBMHTTP \
 "-Wa,goff" "-Wc,langlvl(EXTC99),float(HEX),agg,expo,list(),so(),search(),\
 goff,xref,gonum,roconst,gonum,asm,asmlib('SYS1.MACLIB'),asmlib('CEE.SCEEMAC'),dll" -Wl,dll \
--I ${ZSS}/h -I ${ZOWECOMMON}/h \
+-I ${ZSS}/h -I ${ZOWECOMMON}/h -I ${ZOWECOMMON}/platform/posix \
 -o "${TARGET}" \
 ../../src/ipExplorerDataService.c \
 ../pluginAPI31.x 

--- a/dataService/build/build64.sh
+++ b/dataService/build/build64.sh
@@ -22,7 +22,7 @@ rm -f "${TARGET}"
 if ! c89 -D_OPEN_THREADS -D_XOPEN_SOURCE=600 -DAPF_AUTHORIZED=0 -DNOIBMHTTP \
 "-Wa,goff" "-Wc,lp64,langlvl(EXTC99),float(HEX),agg,expo,list(),so(),search(),\
 goff,xref,gonum,roconst,gonum,asm,asmlib('SYS1.MACLIB'),asmlib('CEE.SCEEMAC'),dll" -Wl,lp64,dll \
--I ${ZSS}/h -I ${ZOWECOMMON}/h \
+-I ${ZSS}/h -I ${ZOWECOMMON}/h -I ${ZOWECOMMON}/platform/posix \
 -o "${TARGET}" \
 ../../src/ipExplorerDataService.c \
 ../pluginAPI64.x 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,15 +1,20 @@
 name: explorer-ip
 id: org.zowe.explorer-ip
+version: 1.0.1
 title: IP Explorer
 description: The Zowe Desktop application to monitor TCP/IP stack using the EZBNMIFR network management interface
+homepage: https://zowe.org
+keywords:
+  - zlux
+  - appfw
+  - app
+  - explorer
+  - network
 license: EPL-2.0
 repository:
   type: git
   url: https://github.com/zowe/explorer-ip.git
-build:
-  branch: "{{build.branch}}"
-  number: "{{build.number}}"
-  commitHash: "{{build.commitHash}}"
-  timestamp: "{{build.timestamp}}"
 appfwPlugins:
   - path: .
+schemas:
+  configs: schemas/trivial-schema.json

--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -1,7 +1,7 @@
 {
   "identifier": "org.zowe.explorer-ip",
-  "apiVersion": "1.0.0",
-  "pluginVersion": "1.0.0",
+  "apiVersion": "2.0.0",
+  "pluginVersion": "1.0.1",
   "pluginType": "application",
   "webContent": {
     "framework": "react",

--- a/schemas/trivial-schema.json
+++ b/schemas/trivial-schema.json
@@ -1,6 +1,6 @@
 {  
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://abcdef.com/schemas/v2/explorer-ip",
+  "$id": "https://zowe.org/schemas/v2/explorer-ip",
   "allOf": [
     { "$ref": "https://zowe.org/schemas/v2/server-base" },
     { 

--- a/schemas/trivial-schema.json
+++ b/schemas/trivial-schema.json
@@ -1,0 +1,21 @@
+{  
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://abcdef.com/schemas/v2/explorer-ip",
+  "allOf": [
+    { "$ref": "https://zowe.org/schemas/v2/server-base" },
+    { 
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {  
+            "explorer-ip": {
+              "$ref": "https://zowe.org/schemas/v2/server-base#zoweComponent"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Proposed changes
Cleans up manifest and adds missing schema file so that this can be installed using configmgr validation.
Also fix zss build because a new header is needed.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Run `zwe components install --component path/to/this` and see if it succeeds. previously, it would not when zowe.useConfigmgr=true, but now it should.