### PR TITLE
Fixed schema missing from pax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,68 @@
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+# This .gitattributes file will cause all text files EXCEPT for
+# git's .gitattributes and .gitignore files to be encoded as EBCDIC.
+# Selected binary files will not be translated at all.
+# The default for text files
+*       git-encoding=iso8859-1 zos-working-tree-encoding=ibm-1047
+# git's files (which MUST be ASCII)
+.gitattributes   git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1
+.gitignore       git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1
+# Binary files, selected by file extension.
+#
+# Note that "Binary" really just means "Not touched when moved
+# between the git repository and the working tree." In some cases
+# these are actually UTF-8 or CP1251 (the usual Windows code page).
+#
+# If you don't have these in your tree, removing these from the
+# .gitattributes file will speed up git's processing a bit.
+#
+# While it would make sense to have BINARY be BINARY on all platforms,
+# Other platforms don't use the BINARY term, But do recognize "binary" macro
+*.jpg   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.crx   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.eot   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.fdt   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.fdx   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.gen   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.gif   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.gz    git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.ico   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.jar   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.jpg   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.node  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.otf   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.png   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.PNG   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.resources   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.scss  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.segments_1   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.so    git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.svg   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.swp   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tar   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tgz   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tii   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tis   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.tree  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.ttf   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.woff  git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.woff2 git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+*.zip   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
+# Always use LF for npm package files because npm cli likes to change line endings.
+package*.json text eol=lf
+# sonar scanning
+sonar-project.properties git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: '[Prep 5] Setup Node'
         uses: actions/setup-node@v2
         with:
-          node-version: 10.24.1
+          node-version: 16
 
       - name: '[Setup] NodeJS project setup'
         uses: zowe-actions/nodejs-actions/setup@main

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -42,7 +42,7 @@ mkdir -p "${PAX_WORKSPACE_DIR}/content"
 echo "[${SCRIPT_NAME}] copying explorer-ip root files to PAX workspace"
 cp  pluginDefinition.json "${PAX_WORKSPACE_DIR}/content"
 cp  manifest.yaml "${PAX_WORKSPACE_DIR}/content"
-cp -r schemas "${PAX_WORKSPACE_DIR}/schemas"
+cp -r schemas "${PAX_WORKSPACE_DIR}/content"
 cp  README.md "${PAX_WORKSPACE_DIR}/content"
 cp  LICENSE "${PAX_WORKSPACE_DIR}/content"
 

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -18,7 +18,7 @@
 # no longer need the following as we are now using github actions
 # set +x
 # . /home/jenkins/.nvm/nvm.sh
-# nvm use v10.24.1
+# nvm use v16
 # set -x
 # constants
 SCRIPT_NAME=$(basename "$0")
@@ -58,7 +58,6 @@ mkdir zlux
 cd zlux
 git clone https://github.com/zowe/zlux-app-manager.git
 git clone https://github.com/zowe/zlux-platform.git
-git submodule foreach "git checkout master"
 cd zlux-app-manager/virtual-desktop && npm ci
 
 # build webClient


### PR DESCRIPTION
The .pax workflow for adding content to the pax was missing the schema folder, so `zwe components install` was failing for this plugin.