### PR TITLE
Update v3 containers

### DIFF
--- a/.github/workflows/explorer-ip-images.yml
+++ b/.github/workflows/explorer-ip-images.yml
@@ -31,8 +31,6 @@ jobs:
           cpu-arch: amd64
 
       - uses: zowe-actions/shared-actions/docker-build-local@main
-        with:
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubuntu
         timeout-minutes: 5
 
   build-ubuntu-s390x:
@@ -58,7 +56,6 @@ jobs:
           zlinux-ssh-user: ${{ secrets.ZLINUX_SSH_USER }}
           zlinux-ssh-key: ${{ secrets.ZLINUX_SSH_KEY }}
           zlinux-ssh-passphrase: ${{ secrets.ZLINUX_SSH_PASSPHRASE }}
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubuntu
         timeout-minutes: 10
 
   define-ubuntu-manifest:
@@ -107,8 +104,6 @@ jobs:
           redhat-registry-password: ${{ secrets.REDHAT_DEVELOPER_PASSWORD }}
 
       - uses: zowe-actions/shared-actions/docker-build-local@main
-        with:
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubi
         timeout-minutes: 5
 
   build-ubi-s390x:
@@ -137,7 +132,6 @@ jobs:
           redhat-registry: ${{ env.DEFAULT_REDHAT_DOCKER_REGISTRY }}
           redhat-registry-user: ${{ secrets.REDHAT_DEVELOPER_USER }}
           redhat-registry-password: ${{ secrets.REDHAT_DEVELOPER_PASSWORD }}
-          build-arg-list: ZOWE_BASE_IMAGE=latest-ubi
         timeout-minutes: 10
 
   define-ubi-manifest:

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,7 +10,7 @@
 #######################################################################
 
 # base image tag
-ARG ZOWE_BASE_IMAGE=latest-ubuntu
+ARG ZOWE_BASE_IMAGE=3-ubuntu
 
 FROM zowe-docker-release.jfrog.io/ompzowe/base-node:${ZOWE_BASE_IMAGE} AS builder
 


### PR DESCRIPTION
This updates the container builds to use the 3-ubuntu rather than latest-ubuntu base image. The latest tag was not specific to any major version, so this tightens the container build while still allowing some flexibility - new v3 container base images will replace 3-ubuntu, so it acts like a latest tag with a better scope.

There is a matching PR for v2.