### PR TITLE
add build info section in manifest (port changes from PR #42)

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,6 +14,11 @@ license: EPL-2.0
 repository:
   type: git
   url: https://github.com/zowe/explorer-ip.git
+build:
+  branch: "{{build.branch}}"
+  number: "{{build.number}}"
+  commitHash: "{{build.commitHash}}"
+  timestamp: {{build.timestamp}}
 appfwPlugins:
   - path: .
 schemas:


### PR DESCRIPTION
Port changes from PR #42  for v2.x/staging

The fix enables the zowe-actions/zlux-builds/plugins/prepare-workflow to generate build information in the manifest.yaml.