### PR TITLE
Fix log injection via unsanitized query-string filter values

### DIFF
--- a/dataService/src/ipExplorerDataService.c
+++ b/dataService/src/ipExplorerDataService.c
@@ -77,10 +77,6 @@ uint64 loggingId;
 
 #define LOG_SANITIZE_BUFSIZE 256
 
-/* Returns a copy of `input` safe to embed in a single log line: control
-   characters (notably CR/LF, which could otherwise be used to inject
-   forged log lines) are stripped out. The returned pointer is only
-   valid until `buffer` is reused. */
 static const char *sanitizeForLog(const char *input, char *buffer, size_t bufferSize) {
   size_t i, j;
   if (input == NULL) {

--- a/dataService/src/ipExplorerDataService.c
+++ b/dataService/src/ipExplorerDataService.c
@@ -75,22 +75,44 @@
 
 uint64 loggingId;
 
+#define LOG_SANITIZE_BUFSIZE 256
+
+/* Returns a copy of `input` safe to embed in a single log line: control
+   characters (notably CR/LF, which could otherwise be used to inject
+   forged log lines) are stripped out. The returned pointer is only
+   valid until `buffer` is reused. */
+static const char *sanitizeForLog(const char *input, char *buffer, size_t bufferSize) {
+  size_t i, j;
+  if (input == NULL) {
+    return "(null)";
+  }
+  for (i = 0, j = 0; input[i] != '\0' && j + 1 < bufferSize; i++) {
+    unsigned char c = (unsigned char)input[i];
+    if (c >= 0x20 && c != 0x7F) {
+      buffer[j++] = (char)c;
+    }
+  }
+  buffer[j] = '\0';
+  return buffer;
+}
+
 typedef struct NMIBufferType_tag{
   NWMHeader    header;
   NWMFilter    filters[MAX_NWM_FILTERS];  /* the filters exist in an OR of an AND of the properties in the NWMFilter Object */
 } NMIBufferType;
 
 void processApplDataFilter(NWMFilter *filter, HttpRequestParam *parm, int filterNumber) {
+  char logBuf[LOG_SANITIZE_BUFSIZE];
   zowelog(NULL, loggingId, ZOWE_LOG_DEBUG2,
           "Http request parameter: %s=%s for filter number %d\n",
-          parm->specification->name, parm->stringValue, filterNumber);
+          parm->specification->name, sanitizeForLog(parm->stringValue, logBuf, sizeof(logBuf)), filterNumber);
 
   filter->NWMFilterFlags |= NWMFILTERAPPLDATAMASK;
   memset(filter->NWMFilterApplData, ' ', 40);
   if (strlen(parm->stringValue) > 40) {
     zowelog(NULL, loggingId, ZOWE_LOG_WARNING,
           "Http request parameter %s=%s will be truncated.\n",
-          parm->specification->name, parm->stringValue);
+          parm->specification->name, sanitizeForLog(parm->stringValue, logBuf, sizeof(logBuf)));
     memcpy(filter->NWMFilterApplData, parm->stringValue, 40);
   }
   else {
@@ -110,10 +132,11 @@ void processAsidFilter(NWMFilter *filter, HttpRequestParam *parm, int filterNumb
 void processIpAddressFilter(NWMFilter *filter, HttpRequestParam *parm, int filterNumber, bool local) {
   int rc;
   struct addrinfo hint, *res = NULL;
+  char logBuf[LOG_SANITIZE_BUFSIZE];
 
   zowelog(NULL, loggingId, ZOWE_LOG_DEBUG2,
           "Http request parameter: %s=%s for filter number %d\n",
-          parm->specification->name, parm->stringValue, filterNumber);
+          parm->specification->name, sanitizeForLog(parm->stringValue, logBuf, sizeof(logBuf)), filterNumber);
 
   memset(&hint, 0, sizeof hint);
   hint.ai_family = PF_UNSPEC;
@@ -123,7 +146,7 @@ void processIpAddressFilter(NWMFilter *filter, HttpRequestParam *parm, int filte
   if (rc) {
     zowelog(NULL, loggingId, ZOWE_LOG_WARNING,
           "Http request parameter error for %s=%s: getaddrinfo() failed with error: %s\n",
-          parm->specification->name, parm->stringValue, gai_strerror(rc));
+          parm->specification->name, sanitizeForLog(parm->stringValue, logBuf, sizeof(logBuf)), gai_strerror(rc));
     zowelog(NULL, loggingId, ZOWE_LOG_WARNING, "Filter criterion will not be applied.\n");
     return ;
   }
@@ -182,16 +205,17 @@ void processResourceIdFilter(NWMFilter *filter, HttpRequestParam *parm, int filt
 }
 
 void processResourceNameFilter(NWMFilter *filter, HttpRequestParam *parm, int filterNumber) {
+  char logBuf[LOG_SANITIZE_BUFSIZE];
   zowelog(NULL, loggingId, ZOWE_LOG_DEBUG2,
           "Http request parameter: %s=%s for filter number %d\n",
-          parm->specification->name, parm->stringValue, filterNumber);
+          parm->specification->name, sanitizeForLog(parm->stringValue, logBuf, sizeof(logBuf)), filterNumber);
 
   filter->NWMFilterFlags |= NWMFILTERRESNAMEMASK;
   memset(filter->NWMFilterResourceName, ' ', 8);
   if (strlen(parm->stringValue) > 8) {
     zowelog(NULL, loggingId, ZOWE_LOG_WARNING,
           "Http request parameter %s=%s will be truncated.\n",
-          parm->specification->name, parm->stringValue);
+          parm->specification->name, sanitizeForLog(parm->stringValue, logBuf, sizeof(logBuf)));
     memcpy(filter->NWMFilterResourceName, parm->stringValue, 8);
   }
   else {
@@ -312,8 +336,9 @@ char *getRsvNameFilter(HttpRequestParam *firstParm) {
   HttpRequestParam *parm;
   for (parm = firstParm; parm != NULL; parm = parm->next) {
     if (strcmp(FPORTRSVNAME, parm->specification->name) == 0) {
+      char logBuf[LOG_SANITIZE_BUFSIZE];
       zowelog(NULL, loggingId, ZOWE_LOG_DEBUG2,
-          "Port reserved name filter is set to %s.\n", parm->stringValue);
+          "Port reserved name filter is set to %s.\n", sanitizeForLog(parm->stringValue, logBuf, sizeof(logBuf)));
       return parm->stringValue;
     }
   }
@@ -1025,11 +1050,12 @@ static int serveMappingService(HttpService *service, HttpResponse *response) {
 
   char *requestType = stringListPrint(request->parsedFile, service->parsedMaskPartCount + 1, 1, "/", 0);  // extract NWM request type from the HTTP request
 
+  char logBuf[LOG_SANITIZE_BUFSIZE];
   zowelog(NULL, loggingId, ZOWE_LOG_DEBUG,
-          "Selected TCPIP stack is %s\n", tcpip);
+          "Selected TCPIP stack is %s\n", sanitizeForLog(tcpip, logBuf, sizeof(logBuf)));
 
   zowelog(NULL, loggingId, ZOWE_LOG_DEBUG,
-          "The request type is: %s\n", requestType);
+          "The request type is: %s\n", sanitizeForLog(requestType, logBuf, sizeof(logBuf)));
 
   // Validate tcpip parameter
   if (strlen(tcpip) > 8) {

--- a/webClient/package-lock.json
+++ b/webClient/package-lock.json
@@ -15,7 +15,6 @@
         "@material-ui/lab": "4.0.0-alpha.60",
         "i18next": "23.14.0",
         "i18next-browser-languagedetector": "8.0.0",
-        "i18next-http-backend": "2.6.1",
         "long": "5.2.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
@@ -1118,14 +1117,6 @@
         "webpack": "^5.1.0"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1892,14 +1883,6 @@
         "@babel/runtime": "^7.23.2"
       }
     },
-    "node_modules/i18next-http-backend": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.6.1.tgz",
-      "integrity": "sha512-rCilMAnlEQNeKOZY1+x8wLM5IpYOj10guGvEpeC59tNjj6MMreLIjIW8D1RclhD3ifLwn6d/Y9HEM1RUE6DSog==",
-      "dependencies": {
-        "cross-fetch": "4.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2459,25 +2442,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-releases": {
@@ -3487,11 +3451,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-loader": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
@@ -3694,11 +3653,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
     "node_modules/webpack": {
       "version": "5.94.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
@@ -3851,15 +3805,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/webClient/package.json
+++ b/webClient/package.json
@@ -10,7 +10,6 @@
     "@material-ui/lab": "4.0.0-alpha.60",
     "i18next": "23.14.0",
     "i18next-browser-languagedetector": "8.0.0",
-    "i18next-http-backend": "2.6.1",
     "long": "5.2.3",
     "react": "16.14.0",
     "react-dom": "16.14.0",


### PR DESCRIPTION
Added a sanitizeForLog() helper that copies a string into a fixed-size buffer while stripping control characters (bytes < 0x20 and 0x7F), including CR/LF

